### PR TITLE
feat(ui): add content to homepage

### DIFF
--- a/CSConfigGenerator/Pages/Home.razor
+++ b/CSConfigGenerator/Pages/Home.razor
@@ -1,7 +1,17 @@
-﻿@page "/"
+@page "/"
 
 <PageTitle>Home</PageTitle>
 
-<h1>Hello, world!</h1>
+<h1>Welcome to the Counter-Strike 2 Config Generator</h1>
 
-Welcome to your new app.
+<p>This tool helps you create personalized configuration files for Counter-Strike 2.</p>
+
+<p>
+    Select one of the options from the navigation bar to get started:
+    <ul>
+        <li><b>Player Config:</b> Customize your personal settings, such as key bindings, crosshair, and viewmodel.</li>
+        <li><b>Server Config:</b> Configure a dedicated server with settings for gameplay, maps, and more.</li>
+    </ul>
+</p>
+
+<p>Once you have configured the settings to your liking, you can download the generated config file.</p>


### PR DESCRIPTION
I've replaced the default Blazor template content on the home page with more descriptive text. The new content explains the purpose of your application (a Counter-Strike 2 config generator) and directs you to the main features: Player Config and Server Config.