### PR TITLE
feat: change event trigger for UI settings

### DIFF
--- a/CSConfigGenerator/Components/Dynamic/DynamicInput.razor
+++ b/CSConfigGenerator/Components/Dynamic/DynamicInput.razor
@@ -53,7 +53,7 @@
                 case SettingType.UnknownNumeric:
                 case SettingType.UnknownInteger:
                 default:
-                    <input type="text" id="@ViewModel.Command.Command" class="form-control" @bind="StringValue" spellcheck="false" />
+                    <input type="text" id="@ViewModel.Command.Command" class="form-control" @bind="StringValue" @bind:event="oninput" spellcheck="false" />
                     break;
             }
         }


### PR DESCRIPTION
I have updated all text-based input fields in the config editor to update their state immediately as you type, rather than waiting for you to press the 'Enter' key or for the field to lose focus.

I achieved this by adding `@bind:event="oninput"` to the text input component, which aligns its behavior with the existing numeric inputs and the main config text area. This provides a more responsive and intuitive experience for you.