### PR TITLE
feat: Implement sticky editor on scroll

### DIFF
--- a/CSConfigGenerator/Components/ConfigEditor.razor
+++ b/CSConfigGenerator/Components/ConfigEditor.razor
@@ -3,7 +3,7 @@
 @inject IPresetService PresetService
 @implements IDisposable
 
-<div class="config-editor">
+<div @ref="_editorDiv" class="config-editor">
     <div class="config-editor-header">
         <h3>Config Preview</h3>
         <div class="config-editor-actions">
@@ -51,6 +51,15 @@
     private string configText = string.Empty;
     private bool copied = false;
     private List<string> _presets = new();
+    private ElementReference _editorDiv;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JSRuntime.InvokeVoidAsync("makeEditorSticky", _editorDiv);
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/CSConfigGenerator/Components/ConfigEditor.razor.css
+++ b/CSConfigGenerator/Components/ConfigEditor.razor.css
@@ -114,3 +114,9 @@
 .refresh-animation {
     animation: spin 0.5s ease-in-out;
 }
+
+.sticky {
+    position: fixed;
+    top: 1rem; /* A bit of margin from the top of the viewport */
+    z-index: 1020; /* Ensure it's above other content, bootstrap's navbar is 1030 */
+}

--- a/CSConfigGenerator/wwwroot/index.html
+++ b/CSConfigGenerator/wwwroot/index.html
@@ -24,6 +24,7 @@
         <span class="dismiss">🗙</span>
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
+    <script src="js/sticky.js"></script>
 </body>
 
 </html>

--- a/CSConfigGenerator/wwwroot/js/sticky.js
+++ b/CSConfigGenerator/wwwroot/js/sticky.js
@@ -9,41 +9,48 @@ window.makeEditorSticky = function (editorElement) {
         return;
     }
 
+    console.log('Initializing sticky editor for element:', editorElement);
+
     const getContainerTop = () => {
-        return editorContainerElement.getBoundingClientRect().top + window.scrollY;
+        const top = editorContainerElement.getBoundingClientRect().top + window.scrollY;
+        console.log('Container top calculated as:', top);
+        return top;
     };
 
-    let containerTop = getContainerTop();
-    
-    // Recalculate on resize to handle responsive layout changes
+    let containerTop = 0;
+
+    // Wait a bit for the layout to stabilize before getting the initial top position
+    setTimeout(() => {
+        containerTop = getContainerTop();
+    }, 200);
+
     window.addEventListener('resize', () => {
-        // Temporarily un-stick to get the correct original position
         const wasSticky = editorElement.classList.contains('sticky');
         if (wasSticky) {
             editorElement.classList.remove('sticky');
         }
-        
         containerTop = getContainerTop();
-
         if (wasSticky) {
             editorElement.classList.add('sticky');
         }
     });
 
     window.addEventListener('scroll', function () {
-        if (window.scrollY > containerTop) {
+        console.log('Scroll Y:', window.scrollY, 'Container Top:', containerTop);
+        if (containerTop > 0 && window.scrollY > containerTop) {
             if (!editorElement.classList.contains('sticky')) {
+                console.log('Making editor sticky');
                 const containerWidth = editorContainerElement.offsetWidth;
-                // Before making it sticky, set a height on the container to prevent collapse.
                 editorContainerElement.style.height = `${editorContainerElement.offsetHeight}px`;
                 editorElement.style.width = `${containerWidth}px`;
                 editorElement.classList.add('sticky');
             }
         } else {
             if (editorElement.classList.contains('sticky')) {
+                console.log('Removing sticky from editor');
                 editorElement.classList.remove('sticky');
                 editorElement.style.width = '';
-                editorContainerElement.style.height = ''; // Remove the height
+                editorContainerElement.style.height = '';
             }
         }
     });

--- a/CSConfigGenerator/wwwroot/js/sticky.js
+++ b/CSConfigGenerator/wwwroot/js/sticky.js
@@ -1,0 +1,50 @@
+window.makeEditorSticky = function (editorElement) {
+    if (!editorElement) {
+        console.warn('Sticky element not provided.');
+        return;
+    }
+    const editorContainerElement = editorElement.parentElement;
+    if (!editorContainerElement) {
+        console.warn('Sticky element\'s container not found.');
+        return;
+    }
+
+    const getContainerTop = () => {
+        return editorContainerElement.getBoundingClientRect().top + window.scrollY;
+    };
+
+    let containerTop = getContainerTop();
+    
+    // Recalculate on resize to handle responsive layout changes
+    window.addEventListener('resize', () => {
+        // Temporarily un-stick to get the correct original position
+        const wasSticky = editorElement.classList.contains('sticky');
+        if (wasSticky) {
+            editorElement.classList.remove('sticky');
+        }
+        
+        containerTop = getContainerTop();
+
+        if (wasSticky) {
+            editorElement.classList.add('sticky');
+        }
+    });
+
+    window.addEventListener('scroll', function () {
+        if (window.scrollY > containerTop) {
+            if (!editorElement.classList.contains('sticky')) {
+                const containerWidth = editorContainerElement.offsetWidth;
+                // Before making it sticky, set a height on the container to prevent collapse.
+                editorContainerElement.style.height = `${editorContainerElement.offsetHeight}px`;
+                editorElement.style.width = `${containerWidth}px`;
+                editorElement.classList.add('sticky');
+            }
+        } else {
+            if (editorElement.classList.contains('sticky')) {
+                editorElement.classList.remove('sticky');
+                editorElement.style.width = '';
+                editorContainerElement.style.height = ''; // Remove the height
+            }
+        }
+    });
+};

--- a/CSConfigGenerator/wwwroot/js/sticky.js
+++ b/CSConfigGenerator/wwwroot/js/sticky.js
@@ -1,8 +1,9 @@
 window.makeEditorSticky = function (editorElement) {
-    if (!editorElement) {
-        console.warn('Sticky element not provided.');
+    if (!editorElement || editorElement.dataset.stickyInitialized) {
         return;
     }
+    editorElement.dataset.stickyInitialized = true;
+
     const editorContainerElement = editorElement.parentElement;
     if (!editorContainerElement) {
         console.warn('Sticky element\'s container not found.');
@@ -17,12 +18,7 @@ window.makeEditorSticky = function (editorElement) {
         return top;
     };
 
-    let containerTop = 0;
-
-    // Wait a bit for the layout to stabilize before getting the initial top position
-    setTimeout(() => {
-        containerTop = getContainerTop();
-    }, 200);
+    let containerTop = getContainerTop();
 
     window.addEventListener('resize', () => {
         const wasSticky = editorElement.classList.contains('sticky');


### PR DESCRIPTION
Adds a "sticky" behavior to the configuration editor component. When a user scrolls down the page, the editor will now stick to the top of the viewport once it is reached.

This is achieved through a combination of:
- A new JavaScript file (`sticky.js`) to handle scroll event listening and DOM manipulation.
- A new CSS class (`.sticky`) to apply the fixed positioning.
- JS Interop in the `ConfigEditor` component to initialize the behavior.

The implementation ensures the editor maintains the correct width and does not cause layout shifts when its position becomes fixed.