### PR TITLE
build: Exclude unused Bootstrap Icons from build

### DIFF
--- a/CSConfigGenerator/CSConfigGenerator.csproj
+++ b/CSConfigGenerator/CSConfigGenerator.csproj
@@ -13,4 +13,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.7" PrivateAssets="all" />
   </ItemGroup>
 
+  <!-- Exclude the massive bootstrap icons folder from the build -->
+  <ItemGroup>
+    <Content Remove="wwwroot/lib/bootstrap-icons/icons/**" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
The build process was slowed down by the presence of over 2000 individual Bootstrap Icon SVG files in the `wwwroot/lib/bootstrap-icons/icons` directory. These files were not being used directly; the application uses the Bootstrap Icons font.

This change modifies the `.csproj` file to exclude these individual icon files from the build's content, which will significantly speed up the build and publish processes without affecting the application's functionality.