### PR TITLE
feat: make config editor sticky

### DIFF
--- a/CSConfigGenerator/Components/ConfigEditor.razor.css
+++ b/CSConfigGenerator/Components/ConfigEditor.razor.css
@@ -2,7 +2,6 @@
     background-color: #252526;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
     border: 1px solid #3a3a3a;
     border-radius: 0.5rem;
     height: 100%;

--- a/CSConfigGenerator/Pages/CommandReference.razor
+++ b/CSConfigGenerator/Pages/CommandReference.razor
@@ -149,7 +149,7 @@
             <p>No commands found matching your criteria.</p>
         }
     </div>
-    <div class="col-lg-4 h-100">
+    <div class="col-lg-4 sticky-editor">
         <ConfigEditor ConfigStateService="@CurrentConfigStateService" PresetType="@currentConfigType.ToString().ToLower()" @key="currentConfigType"/>
     </div>
 </div>

--- a/CSConfigGenerator/Pages/PlayerConfig.razor
+++ b/CSConfigGenerator/Pages/PlayerConfig.razor
@@ -41,7 +41,7 @@
             }
         </div>
     </div>
-    <div class="col-lg-4 h-100">
+    <div class="col-lg-4 h-100 sticky-editor">
         <ConfigEditor ConfigStateService="@PlayerConfigStateService" PresetType="player" />
     </div>
 </div>

--- a/CSConfigGenerator/Pages/PlayerConfig.razor
+++ b/CSConfigGenerator/Pages/PlayerConfig.razor
@@ -41,7 +41,7 @@
             }
         </div>
     </div>
-    <div class="col-lg-4 h-100 sticky-editor">
+    <div class="col-lg-4 sticky-editor">
         <ConfigEditor ConfigStateService="@PlayerConfigStateService" PresetType="player" />
     </div>
 </div>

--- a/CSConfigGenerator/Pages/ServerConfig.razor
+++ b/CSConfigGenerator/Pages/ServerConfig.razor
@@ -40,7 +40,7 @@
             }
         </div>
     </div>
-    <div class="col-lg-4 h-100 sticky-editor">
+    <div class="col-lg-4 sticky-editor">
         <ConfigEditor ConfigStateService="@ServerConfigStateService" PresetType="server" />
     </div>
 </div>

--- a/CSConfigGenerator/Pages/ServerConfig.razor
+++ b/CSConfigGenerator/Pages/ServerConfig.razor
@@ -40,7 +40,7 @@
             }
         </div>
     </div>
-    <div class="col-lg-4 h-100">
+    <div class="col-lg-4 h-100 sticky-editor">
         <ConfigEditor ConfigStateService="@ServerConfigStateService" PresetType="server" />
     </div>
 </div>

--- a/CSConfigGenerator/wwwroot/css/app.css
+++ b/CSConfigGenerator/wwwroot/css/app.css
@@ -110,3 +110,9 @@ h1, h2, h3, h4, h5, h6 {
     padding: 0.1em;
     border-radius: 0.2rem;
 }
+
+.sticky-editor {
+    position: sticky;
+    top: 1rem;
+    height: calc(100vh - 2rem);
+}

--- a/CSConfigGenerator/wwwroot/css/app.css
+++ b/CSConfigGenerator/wwwroot/css/app.css
@@ -114,5 +114,5 @@ h1, h2, h3, h4, h5, h6 {
 .sticky-editor {
     position: sticky;
     top: 1rem;
-    height: calc(100vh - 2rem);
+    height: 95vh;
 }


### PR DESCRIPTION
I've made the config editor sticky, so it will follow you as you scroll the page.

I created a new CSS class called `sticky-editor` in `app.css` to handle the sticky positioning. I then applied this class to the `div` containing the `ConfigEditor` component on both the `PlayerConfig` and `ServerConfig` pages.