### PR TITLE
feat: Add toast messages for user actions

### DIFF
--- a/CSConfigGenerator/Components/ConfigEditor.razor
+++ b/CSConfigGenerator/Components/ConfigEditor.razor
@@ -1,8 +1,10 @@
 @using CSConfigGenerator.Interfaces
 @using Microsoft.AspNetCore.Components.Forms
+@using CSConfigGenerator.Services
 @inject IJSRuntime JSRuntime
 @inject IPresetService PresetService
 @inject IUserConfigService UserConfigService
+@inject ToastService ToastService
 @implements IDisposable
 
 <div class="config-editor">
@@ -134,6 +136,7 @@
         {
             await UserConfigService.SaveConfigAsync(PresetType, configName, configText);
             await LoadUserConfigs();
+            ToastService.ShowToast($"Config '{configName}' saved successfully.", ToastLevel.Success);
         }
     }
 
@@ -142,12 +145,20 @@
         var file = e.File;
         if (file != null)
         {
-            using var stream = file.OpenReadStream(file.Size);
-            using var reader = new StreamReader(stream);
-            var content = await reader.ReadToEndAsync();
-            ConfigStateService.ParseConfigFile(content, this);
-            RefreshConfigText();
-            StateHasChanged();
+            try
+            {
+                using var stream = file.OpenReadStream(file.Size);
+                using var reader = new StreamReader(stream);
+                var content = await reader.ReadToEndAsync();
+                ConfigStateService.ParseConfigFile(content, this);
+                RefreshConfigText();
+                StateHasChanged();
+                ToastService.ShowToast($"Config '{file.Name}' uploaded successfully.", ToastLevel.Success);
+            }
+            catch (Exception ex)
+            {
+                ToastService.ShowToast($"Error uploading file: {ex.Message}", ToastLevel.Error);
+            }
         }
     }
 
@@ -157,6 +168,7 @@
         {
             var fileName = $"{PresetType}_config.cfg";
             await JSRuntime.InvokeVoidAsync("downloadFile", fileName, configText);
+            ToastService.ShowToast("Config downloaded successfully.", ToastLevel.Success);
         }
     }
 
@@ -202,6 +214,7 @@
     private void ResetToDefaults()
     {
         ConfigStateService.ResetToDefaults();
+        ToastService.ShowToast("Config reset to default values.", ToastLevel.Info);
     }
 
     private async Task CopyToClipboard()
@@ -210,11 +223,13 @@
         {
             copied = true;
             await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", configText);
+            ToastService.ShowToast("Config copied to clipboard.", ToastLevel.Success);
             await Task.Delay(1000);
             copied = false;
         }
         catch (Exception ex)
         {
+            ToastService.ShowToast($"Failed to copy to clipboard: {ex.Message}", ToastLevel.Error);
             Console.WriteLine($"Failed to copy to clipboard: {ex.Message}");
         }
     }

--- a/CSConfigGenerator/Components/ToastContainer.razor
+++ b/CSConfigGenerator/Components/ToastContainer.razor
@@ -2,7 +2,7 @@
 @inject ToastService ToastService
 @implements IDisposable
 
-<div class="toast-container position-fixed top-0 end-0 p-3">
+<div class="toast-container position-fixed top-0 start-50 translate-middle-x p-3" style="z-index: 1080;">
     @if (toastMessage != null)
     {
         <div class="@toastCssClass" role="alert" aria-live="assertive" aria-atomic="true">

--- a/CSConfigGenerator/Pages/PlayerConfig.razor
+++ b/CSConfigGenerator/Pages/PlayerConfig.razor
@@ -4,6 +4,7 @@
 @using CSConfigGenerator.Interfaces
 @using Microsoft.Extensions.DependencyInjection
 @using CSConfigGenerator.ViewModels
+@using CSConfigGenerator.Services
 @implements IDisposable
 
 <PageTitle>Player Settings</PageTitle>
@@ -51,6 +52,8 @@
     public IConfigStateService PlayerConfigStateService { get; set; } = default!;
     [Inject]
     public ISchemaService SchemaService { get; set; } = default!;
+    [Inject]
+    public ToastService ToastService { get; set; } = default!;
 
     private readonly Dictionary<string, SettingViewModel> _settingViewModels = new();
 
@@ -74,6 +77,7 @@
     private void ResetToDefaults()
     {
         PlayerConfigStateService.ResetToDefaults();
+        ToastService.ShowToast("Player config reset to default values.", ToastLevel.Info);
     }
     public void Dispose()
     {

--- a/CSConfigGenerator/Pages/ServerConfig.razor
+++ b/CSConfigGenerator/Pages/ServerConfig.razor
@@ -3,6 +3,7 @@
 @using CSConfigGenerator.Components.Dynamic
 @using CSConfigGenerator.Interfaces
 @using CSConfigGenerator.ViewModels
+@using CSConfigGenerator.Services
 @implements IDisposable
 
 <PageTitle>Server Settings</PageTitle>
@@ -50,6 +51,8 @@
     public IConfigStateService ServerConfigStateService { get; set; } = default!;
     [Inject]
     public ISchemaService SchemaService { get; set; } = default!;
+    [Inject]
+    public ToastService ToastService { get; set; } = default!;
 
     private readonly Dictionary<string, SettingViewModel> _settingViewModels = new();
 
@@ -74,6 +77,7 @@
     private void ResetToDefaults()
     {
         ServerConfigStateService.ResetToDefaults();
+        ToastService.ShowToast("Server config reset to default values.", ToastLevel.Info);
     }
 
     public void Dispose()


### PR DESCRIPTION
This commit introduces toast messages to provide users with feedback for various actions, such as saving a config, copying to clipboard, and resetting settings.

The toast container's position has been moved to the top-center of the screen for better visibility.