### PR TITLE
refactor(classification): Extract classification rules to separate files

### DIFF
--- a/Tools/data/classified_commands/uncategorized_commands.json
+++ b/Tools/data/classified_commands/uncategorized_commands.json
@@ -1,0 +1,5469 @@
+[
+  {
+    "command": "Test_ExitProcess",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Test_ExitProcess <exit code> - immediately kill the process.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "Test_ExitProcess",
+      "helperText": "Test_ExitProcess <exit code> - immediately kill the process.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "_record",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Record a demo incrementally.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "_record",
+      "helperText": "Record a demo incrementally.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "alias",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Alias a command.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "alias",
+      "helperText": "Alias a command.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "anim_resource_validate_on_load",
+    "consoleData": {
+      "defaultValue": "true",
+      "flags": [
+        "release"
+      ],
+      "description": "Validates the animation group channel list against the animations on load for every animation",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "anim_resource_validate_on_load",
+      "helperText": "Validates the animation group channel list against the animations on load for every animation",
+      "type": "bool",
+      "defaultValue": true,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "benchframe",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Takes a snapshot of a particular frame in a time demo.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "benchframe",
+      "helperText": "Takes a snapshot of a particular frame in a time demo.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "bind",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Bind a key.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "bind",
+      "helperText": "Bind a key.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": false,
+      "arguments": []
+    }
+  },
+  {
+    "command": "binddefaults",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Bind all keys to their default values.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "binddefaults",
+      "helperText": "Bind all keys to their default values.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "bindss",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Bind a key for a particular splitscreen player.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "bindss",
+      "helperText": "Bind a key for a particular splitscreen player.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "button_info",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Display information about the specified key or button.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "button_info",
+      "helperText": "Display information about the specified key or button.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "changelevel",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "changelevel <mapname> :Multiplayer change level.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "changelevel",
+      "helperText": "changelevel <mapname> :Multiplayer change level.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "clear",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Clear console output.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "clear",
+      "helperText": "Clear console output.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "clearall",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Clear console output from all views.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "clearall",
+      "helperText": "Clear console output from all views.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "clientport",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "release"
+      ],
+      "description": "If non-zero, client binds port to specific address.  Usually you should leave this blank to use a different random system-assigned port for each connection.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "clientport",
+      "helperText": "If non-zero, client binds port to specific address.  Usually you should leave this blank to use a different random system-assigned port for each connection.",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "condump",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "dump the text currently in the console to condumpXX.log",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "condump",
+      "helperText": "dump the text currently in the console to condumpXX.log",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "connect",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Connect to a remote server.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "connect",
+      "helperText": "Connect to a remote server.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "connect_hltv",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Connect to a remote HLTV server.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "connect_hltv",
+      "helperText": "Connect to a remote HLTV server.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "consoletool",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Open a VConsole subtool.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "consoletool",
+      "helperText": "Open a VConsole subtool.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "crash",
+    "consoleData": {
+      "sourcedAt": "2025-07-30T00:00:00Z",
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Crash the client. Optional parameter -- type of crash:  0: read from NULL  1: write to NULL  2: force an Assert  3: infinite loop  4: stack buffer overrun  5: multiple asserts across multiple threads. Optional number of threads (default 5)  6: looping memory leak until we're out of memory. Optional allocation size in bytes (default 1048576/1MB)"
+    },
+    "uiData": {
+      "label": "crash",
+      "helperText": "Crash the client. Optional parameter -- type of crash:  0: read from NULL  1: write to NULL  2: force an Assert  3: infinite loop  4: stack buffer overrun  5: multiple asserts across multiple threads",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "crash_error",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Cause the engine to crash by Plat_FatalError on main thread (Debug!!)",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "crash_error",
+      "helperText": "Cause the engine to crash by Plat_FatalError on main thread (Debug!!)",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "crash_error_job",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Cause the engine to crash by Plat_FatalError on job thread (Debug!!)",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "crash_error_job",
+      "helperText": "Cause the engine to crash by Plat_FatalError on job thread (Debug!!)",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "crash_error_thread",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Cause the engine to crash by Plat_FatalError on non-main thread (Debug!!)",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "crash_error_thread",
+      "helperText": "Cause the engine to crash by Plat_FatalError on non-main thread (Debug!!)",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "crash_job",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Cause the engine to crash in a job thread (Debug!!)",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "crash_job",
+      "helperText": "Cause the engine to crash in a job thread (Debug!!)",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "crash_thread",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Cause the engine to crash in a brand new non-main thread (Debug!!)",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "crash_thread",
+      "helperText": "Cause the engine to crash in a brand new non-main thread (Debug!!)",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "csm_bias_override_0",
+    "consoleData": {
+      "defaultValue": "1",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_bias_override_0",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 1,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_bias_override_1",
+    "consoleData": {
+      "defaultValue": "1",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_bias_override_1",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 1,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_bias_override_2",
+    "consoleData": {
+      "defaultValue": "1",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_bias_override_2",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 1,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_bias_override_3",
+    "consoleData": {
+      "defaultValue": "1",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_bias_override_3",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 1,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_cascade0_override_dist",
+    "consoleData": {
+      "defaultValue": "-1",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_cascade0_override_dist",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": -1,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_cascade1_override_dist",
+    "consoleData": {
+      "defaultValue": "-1",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_cascade1_override_dist",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": -1,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_cascade2_override_dist",
+    "consoleData": {
+      "defaultValue": "-1",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_cascade2_override_dist",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": -1,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_cascade3_override_dist",
+    "consoleData": {
+      "defaultValue": "-1",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_cascade3_override_dist",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": -1,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_cascade_viewdir_shadow_bias_scale",
+    "consoleData": {
+      "defaultValue": "2",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_cascade_viewdir_shadow_bias_scale",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 2,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_max_dist_between_caster_and_receiver",
+    "consoleData": {
+      "defaultValue": "15000",
+      "flags": [
+        "cheat"
+      ],
+      "description": "default pushback",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_max_dist_between_caster_and_receiver",
+      "helperText": "default pushback",
+      "type": "unknown_numeric",
+      "defaultValue": 15000,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_max_visible_dist",
+    "consoleData": {
+      "defaultValue": "7500",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_max_visible_dist",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 7500,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_res_override_0",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_res_override_0",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_res_override_1",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_res_override_1",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_res_override_2",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_res_override_2",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_res_override_3",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_res_override_3",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_shadow_worldview_align_x_to_u",
+    "consoleData": {
+      "defaultValue": "true",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_shadow_worldview_align_x_to_u",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": true,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_shadow_worldview_shear_align_z_to_v",
+    "consoleData": {
+      "defaultValue": "true",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_shadow_worldview_shear_align_z_to_v",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": true,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_split_log_scalar",
+    "consoleData": {
+      "defaultValue": "0.85",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_split_log_scalar",
+      "helperText": "",
+      "type": "float",
+      "defaultValue": 0.85,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "range": {
+        "minValue": -1,
+        "maxValue": -1,
+        "step": -1
+      }
+    }
+  },
+  {
+    "command": "csm_sst_max_visible_dist",
+    "consoleData": {
+      "defaultValue": "2000",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_sst_max_visible_dist",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 2000,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_sst_pushback_distance",
+    "consoleData": {
+      "defaultValue": "1500",
+      "flags": [
+        "cheat"
+      ],
+      "description": "default pushback",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_sst_pushback_distance",
+      "helperText": "default pushback",
+      "type": "unknown_numeric",
+      "defaultValue": 1500,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_sst_shadow_focus_region_maxz",
+    "consoleData": {
+      "defaultValue": "2000",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_sst_shadow_focus_region_maxz",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 2000,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_sst_shadow_focus_region_minz",
+    "consoleData": {
+      "defaultValue": "-2000",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_sst_shadow_focus_region_minz",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": -2000,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_viewdir_shadow_bias",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_viewdir_shadow_bias",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_viewmodel_farz",
+    "consoleData": {
+      "defaultValue": "30",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_viewmodel_farz",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 30,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_viewmodel_max_shadow_dist",
+    "consoleData": {
+      "defaultValue": "21",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_viewmodel_max_shadow_dist",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 21,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_viewmodel_max_visible_dist",
+    "consoleData": {
+      "defaultValue": "1000",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_viewmodel_max_visible_dist",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 1000,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "csm_viewmodel_nearz",
+    "consoleData": {
+      "defaultValue": "0.5",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "csm_viewmodel_nearz",
+      "helperText": "",
+      "type": "float",
+      "defaultValue": 0.5,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "range": {
+        "minValue": -1,
+        "maxValue": -1,
+        "step": -1
+      }
+    }
+  },
+  {
+    "command": "cvarlist",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Show the list of convars/concommands.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "cvarlist",
+      "helperText": "Show the list of convars/concommands.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "cyclevar",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Cycle through specified convar values.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "cyclevar",
+      "helperText": "Cycle through specified convar values.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "demolist",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Print demo sequence list.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "demolist",
+      "helperText": "Print demo sequence list.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "developer",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "release"
+      ],
+      "description": "Set developer message level.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "developer",
+      "helperText": "Set developer message level.",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "differences",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Show all convars which are not at their default values (optional restricted to specific flags).",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "differences",
+      "helperText": "Show all convars which are not at their default values (optional restricted to specific flags).",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "disconnect",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Disconnect from server",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "disconnect",
+      "helperText": "Disconnect from server",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "dota_enable_spatial_audio",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "release"
+      ],
+      "description": "Flag to enable spatial audio in Dota 2.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "dota_enable_spatial_audio",
+      "helperText": "Flag to enable spatial audio in Dota 2.",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "dota_spatial_audio_mix",
+    "consoleData": {
+      "defaultValue": "1",
+      "flags": [
+        "release"
+      ],
+      "description": "Mix value to blend spatial and non-spatial audio in Dota 2.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "dota_spatial_audio_mix",
+      "helperText": "Mix value to blend spatial and non-spatial audio in Dota 2.",
+      "type": "unknown_numeric",
+      "defaultValue": 1,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "dsp_dist_max",
+    "consoleData": {
+      "defaultValue": "1440",
+      "flags": [
+        "cheat",
+        "demo"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "dsp_dist_max",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 1440,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "dsp_dist_min",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "cheat",
+        "demo"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "dsp_dist_min",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "dsp_off",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "dsp_off",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "dump_panorama_css_properties",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Prints out all valid panorama CSS properties and their documentation",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "dump_panorama_css_properties",
+      "helperText": "Prints out all valid panorama CSS properties and their documentation",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "dump_panorama_events",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "print panorama event types and their documentation",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "dump_panorama_events",
+      "helperText": "print panorama event types and their documentation",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "dumpparticlelist",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Print out information on existing particle systems",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "dumpparticlelist",
+      "helperText": "Print out information on existing particle systems",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "echo",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "server_can_execute"
+      ],
+      "description": "Echo text to console.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "echo",
+      "helperText": "Echo text to console.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "echoln",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Echo the command arguments on the console",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "echoln",
+      "helperText": "Echo the command arguments on the console",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "engine_low_latency_sleep_after_client_tick",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "release"
+      ],
+      "description": "When r_low_latency is enabled, this moves the low latency sleep on tick frames to happen after client simulation.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "engine_low_latency_sleep_after_client_tick",
+      "helperText": "When r_low_latency is enabled, this moves the low latency sleep on tick frames to happen after client simulation.",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "engine_show_frame_pacing",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "release"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "engine_show_frame_pacing",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "escape",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release",
+        "clientcmd_can_execute"
+      ],
+      "description": "Escape key pressed.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "escape",
+      "helperText": "Escape key pressed.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "exec",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Execute a cfg file",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "exec",
+      "helperText": "Execute a cfg file",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "exec_async",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat",
+        "norecord"
+      ],
+      "description": "Execute a cfg file over time",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "exec_async",
+      "helperText": "Execute a cfg file over time",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "execifexists",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Execute a cfg file if file exists",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "execifexists",
+      "helperText": "Execute a cfg file if file exists",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "execute_command_every_frame",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "execute_command_every_frame",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "find",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Find concommands with the specified string in their name/help text.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "find",
+      "helperText": "Find concommands with the specified string in their name/help text.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "findflags",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Find concommands by flags.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "findflags",
+      "helperText": "Find concommands by flags.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "fog_override_color",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Sets the fog color override",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "fog_override_color",
+      "helperText": "Sets the fog color override",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "fog_override_enable",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "Use fog_override convars instead of world fog data",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "fog_override_enable",
+      "helperText": "Use fog_override convars instead of world fog data",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "fog_override_end",
+    "consoleData": {
+      "defaultValue": "3500",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "fog_override_end",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 3500,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "fog_override_exponent",
+    "consoleData": {
+      "defaultValue": "2",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "fog_override_exponent",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 2,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "fog_override_max_density",
+    "consoleData": {
+      "defaultValue": "0.4",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "fog_override_max_density",
+      "helperText": "",
+      "type": "float",
+      "defaultValue": 0.4,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "range": {
+        "minValue": -1,
+        "maxValue": -1,
+        "step": -1
+      }
+    }
+  },
+  {
+    "command": "fog_override_start",
+    "consoleData": {
+      "defaultValue": "1000",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "fog_override_start",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 1000,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "fs_fake_read_delay_ms",
+    "consoleData": {
+      "sourcedAt": "2025-07-30T00:00:00Z",
+      "defaultValue": "0",
+      "flags": [
+        "release"
+      ],
+      "description": "Add N ms of delay to every low-level read operation, to simulate a slow disk"
+    },
+    "uiData": {
+      "label": "fs_fake_read_delay_ms",
+      "helperText": "Add N ms of delay to every low-level read operation, to simulate a slow disk",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "fs_report_sync_opens",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "release"
+      ],
+      "description": "0:Off, 1:Always, 2:Not during load",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "fs_report_sync_opens",
+      "helperText": "0:Off, 1:Always, 2:Not during load",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "fs_spew_readfieldlist",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "index <threshold bytes>: spew changes to ent index, optionally only spewing if update is > than threshold bytes",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "fs_spew_readfieldlist",
+      "helperText": "index <threshold bytes>: spew changes to ent index, optionally only spewing if update is > than threshold bytes",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "game_alias",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Set the configuration of game type and mode based on game alias like 'deathmatch'.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "game_alias",
+      "helperText": "Set the configuration of game type and mode based on game alias like 'deathmatch'.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "gameui_hide",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Hides the game UI",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "gameui_hide",
+      "helperText": "Hides the game UI",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "grep",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "grep line for pattern, print out matching lines only",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "grep",
+      "helperText": "grep line for pattern, print out matching lines only",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "help",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Find help about a convar/concommand.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "help",
+      "helperText": "Find help about a convar/concommand.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "hideconsole",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Hide the console.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "hideconsole",
+      "helperText": "Hide the console.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "host_framerate",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "release"
+      ],
+      "description": "Set to lock per-frame time elapse.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "host_framerate",
+      "helperText": "Set to lock per-frame time elapse.",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "host_readconfig_ignore_userconfig",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "Whether we should ignore the user config file for reading/writing.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "host_readconfig_ignore_userconfig",
+      "helperText": "Whether we should ignore the user config file for reading/writing.",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "host_timescale_dec",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Decrement the timescale by one step",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "host_timescale_dec",
+      "helperText": "Decrement the timescale by one step",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "host_timescale_inc",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Increment the timescale by one step",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "host_timescale_inc",
+      "helperText": "Increment the timescale by one step",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "host_writeconfig",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Saves out the user config values.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "host_writeconfig",
+      "helperText": "Saves out the user config values.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "hostip",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "release"
+      ],
+      "description": "Host game server ip",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "hostip",
+      "helperText": "Host game server ip",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "hostname",
+    "consoleData": {
+      "defaultValue": "Tinnitus",
+      "flags": [
+        "release"
+      ],
+      "description": "Hostname for server.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "hostname",
+      "helperText": "Hostname for server.",
+      "type": "string",
+      "defaultValue": "Tinnitus",
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "hostname_in_client_status",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "release"
+      ],
+      "description": "Show server hostname in client status.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "hostname_in_client_status",
+      "helperText": "Show server hostname in client status.",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "hostport",
+    "consoleData": {
+      "defaultValue": "27015",
+      "flags": [
+        "release"
+      ],
+      "description": "Host game server port",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "hostport",
+      "helperText": "Host game server port",
+      "type": "unknown_numeric",
+      "defaultValue": 27015,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "incrementvar",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Increment specified convar value.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "incrementvar",
+      "helperText": "Increment specified convar value.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "input_forceuser",
+    "consoleData": {
+      "defaultValue": "-1",
+      "flags": [
+        "cheat"
+      ],
+      "description": "Force user input to this split screen player.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "input_forceuser",
+      "helperText": "Force user input to this split screen player.",
+      "type": "unknown_numeric",
+      "defaultValue": -1,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "ip",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "release"
+      ],
+      "description": "Overrides IP for multihomed hosts",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "ip",
+      "helperText": "Overrides IP for multihomed hosts",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "iv_debugbone",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "release"
+      ],
+      "description": "Debug bone name for interpolation spew of CAnimationState.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "iv_debugbone",
+      "helperText": "Debug bone name for interpolation spew of CAnimationState.",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "key_findbinding",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Find key bound to specified command string.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "key_findbinding",
+      "helperText": "Find key bound to specified command string.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "key_listboundkeys",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "List bound keys with bindings.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "key_listboundkeys",
+      "helperText": "List bound keys with bindings.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "kick",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Kick a player by name.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "kick",
+      "helperText": "Kick a player by name.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "kickid",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Kick a player by userid or uniqueid, with a message.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "kickid",
+      "helperText": "Kick a player by userid or uniqueid, with a message.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "kickid_hltv",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Kick a player by userid or uniqueid, with a message.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "kickid_hltv",
+      "helperText": "Kick a player by userid or uniqueid, with a message.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "lb_barnlight_shadowmap_scale",
+    "consoleData": {
+      "defaultValue": "0.75",
+      "flags": [
+        "release"
+      ],
+      "description": "Scale for computed barnlight shadowmap size",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "lb_barnlight_shadowmap_scale",
+      "helperText": "Scale for computed barnlight shadowmap size",
+      "type": "float",
+      "defaultValue": 0.75,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "range": {
+        "minValue": -1,
+        "maxValue": -1,
+        "step": -1
+      }
+    }
+  },
+  {
+    "command": "lb_shadow_map_cull_empty_mixed",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "Don't render shadows for mixed shadowmaps with no dynamics objects in view",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "lb_shadow_map_cull_empty_mixed",
+      "helperText": "Don't render shadows for mixed shadowmaps with no dynamics objects in view",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "lb_shadow_map_culling",
+    "consoleData": {
+      "defaultValue": "true",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "lb_shadow_map_culling",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": true,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "listdemo",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "List demo file contents.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "listdemo",
+      "helperText": "List demo file contents.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "log",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Enables logging to file, console, and udp < on | off >.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "log",
+      "helperText": "Enables logging to file, console, and udp < on | off >.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "log_color",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Set the color of a logging channel.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "log_color",
+      "helperText": "Set the color of a logging channel.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "log_dumpchannels",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Dumps information about all logging channels.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "log_dumpchannels",
+      "helperText": "Dumps information about all logging channels.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "log_flags",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Set the flags on a logging channel.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "log_flags",
+      "helperText": "Set the flags on a logging channel.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "log_level",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Set the spew level of a logging channel.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "log_level",
+      "helperText": "Set the spew level of a logging channel.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "log_verbosity",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Set the verbosity of a logging channel.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "log_verbosity",
+      "helperText": "Set the verbosity of a logging channel.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "map",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release",
+        "vconsole_fuzzy",
+        "vconsole_set_focus"
+      ],
+      "description": "map <mapname> :Load a new map.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "map",
+      "helperText": "map <mapname> :Load a new map.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "maps",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Displays list of maps.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "maps",
+      "helperText": "Displays list of maps.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "mm_dedicated_force_servers",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "release"
+      ],
+      "description": "Comma delimited list of ip:port of servers used to search for dedicated servers instead of searching for public servers. Use syntax `publicip1:port|privateip1:port,publicip2:port|privateip2:port` if your server is behind NAT. If the server is behind NAT, you can specify `0.0.0.0|privateip:port` and if server port is in the list of `mm_server_search_lan_ports` its public address should be automatically detected.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "mm_dedicated_force_servers",
+      "helperText": "Comma delimited list of ip:port of servers used to search for dedicated servers instead of searching for public servers. Use syntax `publicip1:port|privateip1:port,publicip2:port|privateip2:port` if your server is behind NAT. If the server is behind NAT, you can specify `0.0.0.0|privateip:port` and if server port is in the list of `mm_server_search_lan_ports` its public address should be automatically detected.",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "mm_session_search_qos_timeout",
+    "consoleData": {
+      "defaultValue": "15",
+      "flags": [
+        "release"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "mm_session_search_qos_timeout",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 15,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "mm_session_sys_kick_ban_duration",
+    "consoleData": {
+      "defaultValue": "180",
+      "flags": [
+        "release"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "mm_session_sys_kick_ban_duration",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 180,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "mm_session_sys_pkey",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "release"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "mm_session_sys_pkey",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "multvar",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Multiply specified convar value.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "multvar",
+      "helperText": "Multiply specified convar value.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "net_channels",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Shows net channel info",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_channels",
+      "helperText": "Shows net channel info",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "net_connections_stats",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Print detailed network statistics for each network connection",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_connections_stats",
+      "helperText": "Print detailed network statistics for each network connection",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "net_fakeclear",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Clear all simulated network conditions",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_fakeclear",
+      "helperText": "Clear all simulated network conditions",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "net_fakejitter",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Shortcut to set jitter net options.  Run with no arguments for usage.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_fakejitter",
+      "helperText": "Shortcut to set jitter net options.  Run with no arguments for usage.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "net_fakelag",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Shortcut to set both FakePacketLag_Recv and FakePacketLag_Send net options",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_fakelag",
+      "helperText": "Shortcut to set both FakePacketLag_Recv and FakePacketLag_Send net options",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "net_fakeloss",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Shortcut to set both FakePacketLoss_Recv and FakePacketLoss_Send net options",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_fakeloss",
+      "helperText": "Shortcut to set both FakePacketLoss_Recv and FakePacketLoss_Send net options",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "net_fakestatus",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Print current simulated network condifions",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_fakestatus",
+      "helperText": "Print current simulated network condifions",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "net_limit_sv_recv_max_message_size_kb",
+    "consoleData": {
+      "defaultValue": "32",
+      "flags": [
+        "release"
+      ],
+      "description": "Server will reject message larger than N kb",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_limit_sv_recv_max_message_size_kb",
+      "helperText": "Server will reject message larger than N kb",
+      "type": "unknown_numeric",
+      "defaultValue": 32,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "net_limit_sv_recv_segments_per_packet",
+    "consoleData": {
+      "defaultValue": "50",
+      "flags": [
+        "release"
+      ],
+      "description": "Server will reject packets with more than N segments",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_limit_sv_recv_segments_per_packet",
+      "helperText": "Server will reject packets with more than N segments",
+      "type": "unknown_numeric",
+      "defaultValue": 50,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "net_limit_sv_recvbuffer_kb",
+    "consoleData": {
+      "defaultValue": "128",
+      "flags": [
+        "release"
+      ],
+      "description": "Server will not buffer more than N kb from connected clients",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_limit_sv_recvbuffer_kb",
+      "helperText": "Server will not buffer more than N kb from connected clients",
+      "type": "unknown_numeric",
+      "defaultValue": 128,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "net_limit_sv_recvbuffer_msg",
+    "consoleData": {
+      "defaultValue": "100",
+      "flags": [
+        "release"
+      ],
+      "description": "Server will not buffer more than N messages from connected clients",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_limit_sv_recvbuffer_msg",
+      "helperText": "Server will not buffer more than N messages from connected clients",
+      "type": "unknown_numeric",
+      "defaultValue": 100,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "net_listallmessages",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "List all registered net messages",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_listallmessages",
+      "helperText": "List all registered net messages",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "net_messageinfo",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Display info about a message (by classname or id)",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_messageinfo",
+      "helperText": "Display info about a message (by classname or id)",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "net_option",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Get or set SteamNetworkingSockets options such as fake packet lag and loss",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_option",
+      "helperText": "Get or set SteamNetworkingSockets options such as fake packet lag and loss",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "net_print_sdr_ping_times",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Print current ping times to SDR points of presence, and selected route",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_print_sdr_ping_times",
+      "helperText": "Print current ping times to SDR points of presence, and selected route",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "net_public_adr",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "release"
+      ],
+      "description": "For servers behind NAT/DHCP meant to be exposed to the public internet, this is the public facing ip address string: ('x.x.x.x' )",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_public_adr",
+      "helperText": "For servers behind NAT/DHCP meant to be exposed to the public internet, this is the public facing ip address string: ('x.x.x.x' )",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "net_showudp",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "release"
+      ],
+      "description": "Dump UDP packets summary to console",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_showudp",
+      "helperText": "Dump UDP packets summary to console",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "net_showudp_remoteonly",
+    "consoleData": {
+      "defaultValue": "true",
+      "flags": [
+        "release"
+      ],
+      "description": "Dump non-loopback udp only",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_showudp_remoteonly",
+      "helperText": "Dump non-loopback udp only",
+      "type": "bool",
+      "defaultValue": true,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "net_status",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Shows current network status",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_status",
+      "helperText": "Shows current network status",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "net_validatemessages",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Activates/deactivates net message validation",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "net_validatemessages",
+      "helperText": "Activates/deactivates net message validation",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "nextdemo",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Play next demo in sequence.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "nextdemo",
+      "helperText": "Play next demo in sequence.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "particles_multiplier",
+    "consoleData": {
+      "defaultValue": "1",
+      "flags": [
+        "cheat"
+      ],
+      "description": "Multiply # of rendered particles by this for perf testing",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "particles_multiplier",
+      "helperText": "Multiply # of rendered particles by this for perf testing",
+      "type": "unknown_numeric",
+      "defaultValue": 1,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "pause",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Toggle the server pause state.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "pause",
+      "helperText": "Toggle the server pause state.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "phys_debug_showdefaultmaterial",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "If enabled, surfaces with default material are highlighted in physics debug geometry.",
+      "sourcedAt": "2025-07-28T00:00:00Z"
+    },
+    "uiData": {
+      "label": "phys_debug_showdefaultmaterial",
+      "helperText": "If enabled, surfaces with default material are highlighted in physics debug geometry.",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    },
+    "deprecated": true
+  },
+  {
+    "command": "phys_highlight_expensive_objects",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "Highlight expensive physics objects",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "phys_highlight_expensive_objects",
+      "helperText": "Highlight expensive physics objects",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "phys_highlight_expensive_objects_strength",
+    "consoleData": {
+      "defaultValue": "0.02",
+      "flags": [
+        "cheat"
+      ],
+      "description": "Highlight expensive physics objects strength",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "phys_highlight_expensive_objects_strength",
+      "helperText": "Highlight expensive physics objects strength",
+      "type": "float",
+      "defaultValue": 0.02,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "range": {
+        "minValue": -1,
+        "maxValue": -1,
+        "step": -1
+      }
+    }
+  },
+  {
+    "command": "pixelvis_debug",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Dump debug info",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "pixelvis_debug",
+      "helperText": "Dump debug info",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "play",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "server_can_execute"
+      ],
+      "description": "Play a sound.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "play",
+      "helperText": "Play a sound.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "playcast",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Play a broadcast",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "playcast",
+      "helperText": "Play a broadcast",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "playdemo",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Play a recorded demo file (.dem ).",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "playdemo",
+      "helperText": "Play a recorded demo file (.dem ).",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "print_changed_convars",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Prints all convars that have changed from their default value",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "print_changed_convars",
+      "helperText": "Prints all convars that have changed from their default value",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "pulse_list_graphs",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "List all the active pulse graph instances",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "pulse_list_graphs",
+      "helperText": "List all the active pulse graph instances",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "pulse_open_graph_id",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Open a specific graph instance by id",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "pulse_open_graph_id",
+      "helperText": "Open a specific graph instance by id",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "pulse_print_graph_execution_history",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Prints the execution history of a graph by filename or instanceid",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "pulse_print_graph_execution_history",
+      "helperText": "Prints the execution history of a graph by filename or instanceid",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "quit",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release",
+        "vconsole_set_focus"
+      ],
+      "description": "Quit the game",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "quit",
+      "helperText": "Quit the game",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "rcon",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Issue an rcon command.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "rcon",
+      "helperText": "Issue an rcon command.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "rcon_address",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "norecord",
+        "release",
+        "server_cant_query"
+      ],
+      "description": "Address of remote server if sending unconnected rcon commands (format x.x.x.x:p)",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "rcon_address",
+      "helperText": "Address of remote server if sending unconnected rcon commands (format x.x.x.x:p)",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "rcon_password",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "norecord",
+        "release",
+        "server_cant_query"
+      ],
+      "description": "remote console password.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "rcon_password",
+      "helperText": "remote console password.",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "record",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Record a demo.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "record",
+      "helperText": "Record a demo.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "reloadgame",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat",
+        "vconsole_set_focus"
+      ],
+      "description": "Reload the most recent saved game.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "reloadgame",
+      "helperText": "Reload the most recent saved game.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "repeat_last_console_command",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Repeat last console command.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "repeat_last_console_command",
+      "helperText": "Repeat last console command.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "reset_gameconvars",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Reset game convars to default values",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "reset_gameconvars",
+      "helperText": "Reset game convars to default values",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "restart",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat",
+        "vconsole_set_focus"
+      ],
+      "description": "Poor man's restart: reload the current map from disk.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "restart",
+      "helperText": "Poor man's restart: reload the current map from disk.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "run_perftest",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat",
+        "norecord"
+      ],
+      "description": "Execute perftest.cfg",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "run_perftest",
+      "helperText": "Execute perftest.cfg",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "sc_aggregate_indirect_draw_compaction",
+    "consoleData": {
+      "defaultValue": "true",
+      "flags": [
+        "release"
+      ],
+      "description": "Use multidrawindirect...count if the driver/hardware supports it",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_aggregate_indirect_draw_compaction",
+      "helperText": "Use multidrawindirect...count if the driver/hardware supports it",
+      "type": "bool",
+      "defaultValue": true,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_aggregate_indirect_draw_compaction_threshold",
+    "consoleData": {
+      "defaultValue": "8",
+      "flags": [
+        "release"
+      ],
+      "description": "Threshold of indirect draws when we will do compaction",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_aggregate_indirect_draw_compaction_threshold",
+      "helperText": "Threshold of indirect draws when we will do compaction",
+      "type": "unknown_numeric",
+      "defaultValue": 8,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_check_world",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-28T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_check_world",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    },
+    "deprecated": true
+  },
+  {
+    "command": "sc_disableThreading",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_disableThreading",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_disable_culling_boxes",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_disable_culling_boxes",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_disable_procedural_layer_rendering",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_disable_procedural_layer_rendering",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_disable_shadow_fastpath",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_disable_shadow_fastpath",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_disable_shadow_materials",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_disable_shadow_materials",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_disable_spotlight_shadows",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_disable_spotlight_shadows",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_disable_world_materials",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_disable_world_materials",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_dump_lists",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_dump_lists",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_dumpworld",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Dump a list of the objects in a sceneworld (Usage: sc_dumpworld <world_index>)",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_dumpworld",
+      "helperText": "Dump a list of the objects in a sceneworld (Usage: sc_dumpworld <world_index>)",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "sc_dumpworld3d",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Dump the objects in a sceneworld into a 3d geoview buffer (Usage: sc_dumpworld3d <world_index>)",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_dumpworld3d",
+      "helperText": "Dump the objects in a sceneworld into a 3d geoview buffer (Usage: sc_dumpworld3d <world_index>)",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "sc_extended_stats",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_extended_stats",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_fade_distance_scale_override",
+    "consoleData": {
+      "defaultValue": "-1",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_fade_distance_scale_override",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": -1,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_force_lod_level",
+    "consoleData": {
+      "defaultValue": "-1",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_force_lod_level",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": -1,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_force_materials_batchable",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_force_materials_batchable",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_force_translation_in_projection",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "If enabled, the camera's translation will be included in the projection matrix.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_force_translation_in_projection",
+      "helperText": "If enabled, the camera's translation will be included in the projection matrix.",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_listworlds",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "List all the active sceneworlds",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_listworlds",
+      "helperText": "List all the active sceneworlds",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "sc_only_render_opaque",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_only_render_opaque",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_only_render_shadowcasters",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_only_render_shadowcasters",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_reject_all_objects",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_reject_all_objects",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_screen_size_lod_scale_override",
+    "consoleData": {
+      "defaultValue": "-1",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_screen_size_lod_scale_override",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": -1,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sc_setclassflags",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Low level command to set the flags byte associated with an object class. sc_SetClassFlags <classname> <value>",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_setclassflags",
+      "helperText": "Low level command to set the flags byte associated with an object class. sc_SetClassFlags <classname> <value>",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "sc_showclasses",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "List the object class names known by scenesystem",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_showclasses",
+      "helperText": "List the object class names known by scenesystem",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "sc_skip_traversal",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sc_skip_traversal",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "screenmessage_show",
+    "consoleData": {
+      "defaultValue": "-1",
+      "flags": [
+        "cheat"
+      ],
+      "description": "Enable display of console messages on screen. 1 = Enabled, 0 = Disabled, -1 = Enabled if vgui is not present",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "screenmessage_show",
+      "helperText": "Enable display of console messages on screen. 1 = Enabled, 0 = Disabled, -1 = Enabled if vgui is not present",
+      "type": "unknown_numeric",
+      "defaultValue": -1,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "sdr",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "An old command that has been renamed to 'net_option'",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sdr",
+      "helperText": "An old command that has been renamed to 'net_option'",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "setinfo",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "clientcmd_can_execute"
+      ],
+      "description": "Adds a new user info value",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "setinfo",
+      "helperText": "Adds a new user info value",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "setpause",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Set the pause state of the server.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "setpause",
+      "helperText": "Set the pause state of the server.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "showconsole",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Show the console.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "showconsole",
+      "helperText": "Show the console.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "silence_dsp",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "When on, silences all DSP mixes.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "silence_dsp",
+      "helperText": "When on, silences all DSP mixes.",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "soundinfo",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Describe the current sound device with an active voice list.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "soundinfo",
+      "helperText": "Describe the current sound device with an active voice list.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "startdemos",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Play demos in demo sequence.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "startdemos",
+      "helperText": "Play demos in demo sequence.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "status",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Print connection status",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "status",
+      "helperText": "Print connection status",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "status_json",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Print status in JSON format",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "status_json",
+      "helperText": "Print status in JSON format",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "stop",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Finish recording demo.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "stop",
+      "helperText": "Finish recording demo.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "stopdemos",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Stop looping demos (current demo will complete).",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "stopdemos",
+      "helperText": "Stop looping demos (current demo will complete).",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "stopsound",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "stopsound",
+      "helperText": "",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "sys_info",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Print system information to the console",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sys_info",
+      "helperText": "Print system information to the console",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "sys_minidumpspewlines",
+    "consoleData": {
+      "defaultValue": "2000",
+      "flags": [
+        "release"
+      ],
+      "description": "Lines of crash dump console spew to keep.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "sys_minidumpspewlines",
+      "helperText": "Lines of crash dump console spew to keep.",
+      "type": "unknown_numeric",
+      "defaultValue": 2000,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "timedemo",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Play a demo and report performance info.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "timedemo",
+      "helperText": "Play a demo and report performance info.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "timedemoquit",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Play a demo, report performance info, and then exit",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "timedemoquit",
+      "helperText": "Play a demo, report performance info, and then exit",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "toggle",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Toggles specified convar value on and off.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "toggle",
+      "helperText": "Toggles specified convar value on and off.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "toggleconsole",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "norecord",
+        "release"
+      ],
+      "description": "Show/hide the console.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "toggleconsole",
+      "helperText": "Show/hide the console.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "tv_advertise_watchable",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "prot",
+        "nf",
+        "norecord",
+        "release"
+      ],
+      "description": "GOTV advertises the match as watchable via game UI, clients watching via UI will not need to type password",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_advertise_watchable",
+      "helperText": "GOTV advertises the match as watchable via game UI, clients watching via UI will not need to type password",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_autorecord",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "release"
+      ],
+      "description": "Automatically records all games as SourceTV demos.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_autorecord",
+      "helperText": "Automatically records all games as SourceTV demos.",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_autoretry",
+    "consoleData": {
+      "defaultValue": "true",
+      "flags": [
+        "release"
+      ],
+      "description": "Relay proxies retry connection after network timeout",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_autoretry",
+      "helperText": "Relay proxies retry connection after network timeout",
+      "type": "bool",
+      "defaultValue": true,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_broadcast",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "release"
+      ],
+      "description": "Automatically broadcasts all games as GOTV demos through Steam.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_broadcast",
+      "helperText": "Automatically broadcasts all games as GOTV demos through Steam.",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_broadcast1",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "release"
+      ],
+      "description": "Automatically broadcasts all games as GOTV[1] demos through Steam.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_broadcast1",
+      "helperText": "Automatically broadcasts all games as GOTV[1] demos through Steam.",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_broadcast_keyframe_interval",
+    "consoleData": {
+      "defaultValue": "3",
+      "flags": [
+        "release"
+      ],
+      "description": "The frequency, in seconds, of sending keyframes and delta fragments to the broadcast relay server",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_broadcast_keyframe_interval",
+      "helperText": "The frequency, in seconds, of sending keyframes and delta fragments to the broadcast relay server",
+      "type": "unknown_numeric",
+      "defaultValue": 3,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_broadcast_keyframe_interval1",
+    "consoleData": {
+      "defaultValue": "3",
+      "flags": [
+        "release"
+      ],
+      "description": "The frequency, in seconds, of sending keyframes and delta fragments to the broadcast1 relay server",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_broadcast_keyframe_interval1",
+      "helperText": "The frequency, in seconds, of sending keyframes and delta fragments to the broadcast1 relay server",
+      "type": "unknown_numeric",
+      "defaultValue": 3,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_broadcast_max_requests",
+    "consoleData": {
+      "defaultValue": "20",
+      "flags": [
+        "release"
+      ],
+      "description": "Max number of broadcast http requests in flight. If there is a network issue, the requests may start piling up, degrading server performance. If more than the specified number of requests are in flight, the new requests are dropped.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_broadcast_max_requests",
+      "helperText": "Max number of broadcast http requests in flight. If there is a network issue, the requests may start piling up, degrading server performance. If more than the specified number of requests are in flight, the new requests are dropped.",
+      "type": "unknown_numeric",
+      "defaultValue": 20,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_broadcast_max_requests1",
+    "consoleData": {
+      "defaultValue": "20",
+      "flags": [
+        "release"
+      ],
+      "description": "Max number of broadcast1 http requests in flight. If there is a network issue, the requests may start piling up, degrading server performance. If more than the specified number of requests are in flight, the new requests are dropped.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_broadcast_max_requests1",
+      "helperText": "Max number of broadcast1 http requests in flight. If there is a network issue, the requests may start piling up, degrading server performance. If more than the specified number of requests are in flight, the new requests are dropped.",
+      "type": "unknown_numeric",
+      "defaultValue": 20,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_broadcast_spew_threshold",
+    "consoleData": {
+      "sourcedAt": "2025-07-30T00:00:00Z",
+      "defaultValue": "0.1",
+      "flags": [
+        "release"
+      ],
+      "description": "The threshold, in seconds, that we'll spew about the snapshot tick"
+    },
+    "uiData": {
+      "label": "tv_broadcast_spew_threshold",
+      "helperText": "The threshold, in seconds, that we'll spew about the snapshot tick",
+      "type": "float",
+      "defaultValue": 0.1,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "range": {
+        "minValue": -1,
+        "maxValue": -1,
+        "step": -1
+      }
+    }
+  },
+  {
+    "command": "tv_broadcast_startup_resend_interval",
+    "consoleData": {
+      "defaultValue": "10",
+      "flags": [
+        "release"
+      ],
+      "description": "The interval, in seconds, of re-sending startup data to the broadcast relay server (useful in case relay crashes, restarts or startup data http request fails)",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_broadcast_startup_resend_interval",
+      "helperText": "The interval, in seconds, of re-sending startup data to the broadcast relay server (useful in case relay crashes, restarts or startup data http request fails)",
+      "type": "unknown_numeric",
+      "defaultValue": 10,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_broadcast_status",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Print out broadcast status",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_broadcast_status",
+      "helperText": "Print out broadcast status",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "tv_broadcast_url",
+    "consoleData": {
+      "defaultValue": "http://localhost:8080",
+      "flags": [
+        "release"
+      ],
+      "description": "URL of the broadcast relay",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_broadcast_url",
+      "helperText": "URL of the broadcast relay",
+      "type": "string",
+      "defaultValue": "http://localhost:8080",
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_broadcast_url1",
+    "consoleData": {
+      "defaultValue": "http://localhost:8080",
+      "flags": [
+        "release"
+      ],
+      "description": "URL of the broadcast relay1",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_broadcast_url1",
+      "helperText": "URL of the broadcast relay1",
+      "type": "string",
+      "defaultValue": "http://localhost:8080",
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_chatgroupsize",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "release"
+      ],
+      "description": "Set the default chat group size",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_chatgroupsize",
+      "helperText": "Set the default chat group size",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_chattimelimit",
+    "consoleData": {
+      "defaultValue": "0.2",
+      "flags": [
+        "release"
+      ],
+      "description": "Limits spectators to chat only every n seconds",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_chattimelimit",
+      "helperText": "Limits spectators to chat only every n seconds",
+      "type": "float",
+      "defaultValue": 0.2,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "range": {
+        "minValue": -1,
+        "maxValue": -1,
+        "step": -1
+      }
+    }
+  },
+  {
+    "command": "tv_clients",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Shows list of connected SourceTV clients.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_clients",
+      "helperText": "Shows list of connected SourceTV clients.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "tv_debug",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "release"
+      ],
+      "description": "SourceTV debug info.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_debug",
+      "helperText": "SourceTV debug info.",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_deltacache",
+    "consoleData": {
+      "defaultValue": "2",
+      "flags": [
+        "release"
+      ],
+      "description": "Enable delta entity bit stream cache",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_deltacache",
+      "helperText": "Enable delta entity bit stream cache",
+      "type": "unknown_numeric",
+      "defaultValue": 2,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_dispatchmode",
+    "consoleData": {
+      "defaultValue": "1",
+      "flags": [
+        "release"
+      ],
+      "description": "Dispatch clients to relay proxies: 0=never, 1=if appropriate, 2=always",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_dispatchmode",
+      "helperText": "Dispatch clients to relay proxies: 0=never, 1=if appropriate, 2=always",
+      "type": "unknown_numeric",
+      "defaultValue": 1,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_enable",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "nf",
+        "release"
+      ],
+      "description": "Activates SourceTV on server.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_enable",
+      "helperText": "Activates SourceTV on server.",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_enable1",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "nf",
+        "release"
+      ],
+      "description": "Activates SourceTV[1] on server.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_enable1",
+      "helperText": "Activates SourceTV[1] on server.",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_enable_delta_frames",
+    "consoleData": {
+      "defaultValue": "true",
+      "flags": [
+        "release"
+      ],
+      "description": "Indicates whether or not the tv should use delta frames for storage of intermediate frames. This takes more CPU but significantly less memory.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_enable_delta_frames",
+      "helperText": "Indicates whether or not the tv should use delta frames for storage of intermediate frames. This takes more CPU but significantly less memory.",
+      "type": "bool",
+      "defaultValue": true,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_enable_dynamic",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "nf",
+        "release"
+      ],
+      "description": "When enabled, changes in tv_enable convars cause immediate startup or shutdown of hltv server",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_enable_dynamic",
+      "helperText": "When enabled, changes in tv_enable convars cause immediate startup or shutdown of hltv server",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_maxclients",
+    "consoleData": {
+      "defaultValue": "128",
+      "flags": [
+        "release"
+      ],
+      "description": "Maximum client number on SourceTV server.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_maxclients",
+      "helperText": "Maximum client number on SourceTV server.",
+      "type": "unknown_numeric",
+      "defaultValue": 128,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_maxclients_relayreserved",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "release"
+      ],
+      "description": "This number of relay client connections are reserved for SourceTV relays.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_maxclients_relayreserved",
+      "helperText": "This number of relay client connections are reserved for SourceTV relays.",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_maxrate",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "release"
+      ],
+      "description": "Max SourceTV spectator bandwidth rate allowed, 0 == unlimited",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_maxrate",
+      "helperText": "Max SourceTV spectator bandwidth rate allowed, 0 == unlimited",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_mem",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "hltv memory statistics. Use with 'ent 10' (dump entity 10 memory usage) or 'top 8' (dump top 8 memory users) or 'class' CWorld (dump CWorld class)",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_mem",
+      "helperText": "hltv memory statistics. Use with 'ent 10' (dump entity 10 memory usage) or 'top 8' (dump top 8 memory users) or 'class' CWorld (dump CWorld class)",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "tv_name",
+    "consoleData": {
+      "defaultValue": "SourceTV",
+      "flags": [
+        "release"
+      ],
+      "description": "SourceTV host name",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_name",
+      "helperText": "SourceTV host name",
+      "type": "string",
+      "defaultValue": "SourceTV",
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_overridemaster",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "release"
+      ],
+      "description": "Overrides the SourceTV master root address.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_overridemaster",
+      "helperText": "Overrides the SourceTV master root address.",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_password",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "prot",
+        "nf",
+        "norecord",
+        "release"
+      ],
+      "description": "SourceTV password for all clients of CSTV[0]",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_password",
+      "helperText": "SourceTV password for all clients of CSTV[0]",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_password1",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "prot",
+        "nf",
+        "norecord",
+        "release"
+      ],
+      "description": "SourceTV password for all clients of CSTV[1]. If empty, tv_password is used",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_password1",
+      "helperText": "SourceTV password for all clients of CSTV[1]. If empty, tv_password is used",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_playcast_delay_prediction",
+    "consoleData": {
+      "defaultValue": "true",
+      "flags": [
+        "release"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_playcast_delay_prediction",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": true,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_playcast_delay_resync",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "release"
+      ],
+      "description": "To alleviate intermittent network connectivity problems, this is the number of seconds to wait before actually re-syncing the stream after failure",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_playcast_delay_resync",
+      "helperText": "To alleviate intermittent network connectivity problems, this is the number of seconds to wait before actually re-syncing the stream after failure",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_playcast_retry_timeout",
+    "consoleData": {
+      "defaultValue": "25",
+      "flags": [
+        "release"
+      ],
+      "description": "In case of intermittent network problems, how long should playcast retry fragment retrieval before resorting to resync",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_playcast_retry_timeout",
+      "helperText": "In case of intermittent network problems, how long should playcast retry fragment retrieval before resorting to resync",
+      "type": "unknown_numeric",
+      "defaultValue": 25,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_port",
+    "consoleData": {
+      "defaultValue": "27020",
+      "flags": [
+        "release"
+      ],
+      "description": "Host SourceTV[0] port",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_port",
+      "helperText": "Host SourceTV[0] port",
+      "type": "unknown_numeric",
+      "defaultValue": 27020,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_port1",
+    "consoleData": {
+      "defaultValue": "27021",
+      "flags": [
+        "release"
+      ],
+      "description": "Host SourceTV[1] port",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_port1",
+      "helperText": "Host SourceTV[1] port",
+      "type": "unknown_numeric",
+      "defaultValue": 27021,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_record",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Starts SourceTV demo recording.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_record",
+      "helperText": "Starts SourceTV demo recording.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "tv_record_immediate",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "release"
+      ],
+      "description": "tv_record starting the moment tv_record was executed, not tv_delay earlier",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_record_immediate",
+      "helperText": "tv_record starting the moment tv_record was executed, not tv_delay earlier",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_relay",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Connect to SourceTV server and relay broadcast.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_relay",
+      "helperText": "Connect to SourceTV server and relay broadcast.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "tv_relaypassword",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "prot",
+        "nf",
+        "norecord",
+        "release"
+      ],
+      "description": "SourceTV password for relay proxies",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_relaypassword",
+      "helperText": "SourceTV password for relay proxies",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_relayvoice",
+    "consoleData": {
+      "defaultValue": "true",
+      "flags": [
+        "release"
+      ],
+      "description": "Relay voice data: 0=off, 1=on",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_relayvoice",
+      "helperText": "Relay voice data: 0=off, 1=on",
+      "type": "bool",
+      "defaultValue": true,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_retry",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Reconnects the SourceTV relay proxy.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_retry",
+      "helperText": "Reconnects the SourceTV relay proxy.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "tv_secure_bypass",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "release"
+      ],
+      "description": "Bypass secure challenge on TV port",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_secure_bypass",
+      "helperText": "Bypass secure challenge on TV port",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_status",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Show SourceTV server status.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_status",
+      "helperText": "Show SourceTV server status.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "tv_stop",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Stops the SourceTV broadcast.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_stop",
+      "helperText": "Stops the SourceTV broadcast.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "tv_stoprecord",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Stops SourceTV demo recording.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_stoprecord",
+      "helperText": "Stops SourceTV demo recording.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "tv_timeout",
+    "consoleData": {
+      "defaultValue": "20",
+      "flags": [
+        "release"
+      ],
+      "description": "SourceTV connection timeout in seconds.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_timeout",
+      "helperText": "SourceTV connection timeout in seconds.",
+      "type": "unknown_numeric",
+      "defaultValue": 20,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_title",
+    "consoleData": {
+      "defaultValue": "SourceTV",
+      "flags": [
+        "release"
+      ],
+      "description": "Set title for SourceTV spectator UI",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_title",
+      "helperText": "Set title for SourceTV spectator UI",
+      "type": "string",
+      "defaultValue": "SourceTV",
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "tv_window_size",
+    "consoleData": {
+      "defaultValue": "16",
+      "flags": [
+        "release"
+      ],
+      "description": "Specifies the number of seconds worth of frames that the tv replay system should keep in memory. Increasing this greatly increases the amount of memory consumed by the TV system",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "tv_window_size",
+      "helperText": "Specifies the number of seconds worth of frames that the tv replay system should keep in memory. Increasing this greatly increases the amount of memory consumed by the TV system",
+      "type": "unknown_numeric",
+      "defaultValue": 16,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "unbind",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Unbind a key.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "unbind",
+      "helperText": "Unbind a key.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "unbindall",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Unbind all keys.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "unbindall",
+      "helperText": "Unbind all keys.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": false,
+      "arguments": []
+    }
+  },
+  {
+    "command": "unpause",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Clear the pause state of the server.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "unpause",
+      "helperText": "Clear the pause state of the server.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "vconsole_rcon_server_details",
+    "consoleData": {
+      "defaultValue": "0",
+      "flags": [
+        "norecord",
+        "release",
+        "server_cant_query"
+      ],
+      "description": "when non-empty allows for easy vconsole connection to the dedicated server.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "vconsole_rcon_server_details",
+      "helperText": "when non-empty allows for easy vconsole connection to the dedicated server.",
+      "type": "unknown_numeric",
+      "defaultValue": 0,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "vmix_input",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Set an input mix value",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "vmix_input",
+      "helperText": "Set an input mix value",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "vmix_output",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "cheat"
+      ],
+      "description": "Dump main graph control output values",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "vmix_output",
+      "helperText": "Dump main graph control output values",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": true,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  },
+  {
+    "command": "voice_test_log_send",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "release"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "voice_test_log_send",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": false,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "volume_fog_debug_volumes",
+    "consoleData": {
+      "defaultValue": "false",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "volume_fog_debug_volumes",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": false,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "volume_fog_dither_scale",
+    "consoleData": {
+      "defaultValue": "1",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "volume_fog_dither_scale",
+      "helperText": "",
+      "type": "unknown_numeric",
+      "defaultValue": 1,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "volume_fog_enable_jitter",
+    "consoleData": {
+      "defaultValue": "true",
+      "flags": [
+        "cheat"
+      ],
+      "description": "",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "volume_fog_enable_jitter",
+      "helperText": "",
+      "type": "bool",
+      "defaultValue": true,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    }
+  },
+  {
+    "command": "vphys2_friction_factor",
+    "consoleData": {
+      "defaultValue": "1",
+      "flags": [
+        "cheat"
+      ],
+      "description": "Change global friction factor",
+      "sourcedAt": "2025-07-28T00:00:00Z"
+    },
+    "uiData": {
+      "label": "vphys2_friction_factor",
+      "helperText": "Change global friction factor",
+      "type": "unknown_numeric",
+      "defaultValue": 1,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    },
+    "deprecated": true
+  },
+  {
+    "command": "vphys2_restitution_factor",
+    "consoleData": {
+      "defaultValue": "1",
+      "flags": [
+        "cheat"
+      ],
+      "description": "Change global restitution factor",
+      "sourcedAt": "2025-07-28T00:00:00Z"
+    },
+    "uiData": {
+      "label": "vphys2_restitution_factor",
+      "helperText": "Change global restitution factor",
+      "type": "unknown_numeric",
+      "defaultValue": 1,
+      "requiresCheats": true,
+      "hideFromDefaultView": true
+    },
+    "deprecated": true
+  },
+  {
+    "command": "writekeybindings",
+    "consoleData": {
+      "defaultValue": null,
+      "flags": [
+        "release"
+      ],
+      "description": "Saves current key bindings to disk.",
+      "sourcedAt": "2025-07-30T00:00:00Z"
+    },
+    "uiData": {
+      "label": "writekeybindings",
+      "helperText": "Saves current key bindings to disk.",
+      "type": "action",
+      "defaultValue": null,
+      "requiresCheats": false,
+      "hideFromDefaultView": true,
+      "arguments": []
+    }
+  }
+]

--- a/Tools/rules/numeric_detection_rules.py
+++ b/Tools/rules/numeric_detection_rules.py
@@ -1,0 +1,36 @@
+from typing import Any
+
+# --- Rule-based classification logic for numeric detection ---
+
+# Configuration for numeric type classification
+FLOAT_RATIO = 0.5
+MIN_INT_OCCURRENCES = 15
+PROTECTED_TYPES = ("float", "bool", "bitmask", "action")
+UNKNOWN_TYPES = ("unknown", "unknown_numeric")
+
+def classify_command_by_usage(stats: Any) -> str:
+    """
+    Determine the appropriate type for a command based on its usage stats.
+
+    Args:
+        stats: A CommandStats object with statistics about the command's usage.
+
+    Returns:
+        The classified type name as a string.
+    """
+    # Don't reclassify protected types that have been manually set
+    if stats.current_type in PROTECTED_TYPES:
+        return stats.current_type
+
+    # Classify as float if a significant ratio of its values are floats
+    if stats.float_ratio > FLOAT_RATIO:
+        return "float"
+
+    # Classify as unknown_integer if all values are integers and it appears often
+    if (stats.total >= MIN_INT_OCCURRENCES and
+        stats.is_all_int and
+        stats.current_type not in ("int", "unknown_integer")):
+        return "unknown_integer"
+
+    # If no specific rule matches, keep the existing type
+    return stats.current_type

--- a/Tools/rules/splitting_rules.py
+++ b/Tools/rules/splitting_rules.py
@@ -1,0 +1,55 @@
+# --- Rule-based classification logic for splitting commands ---
+
+PLAYER_PREFIXES = ["cl_", "ui_", "joy_", "cam_", "c_", "+", "snd_", "r_", "mat_", "demo_"]
+SERVER_PREFIXES = ["sv_", "mp_", "bot_", "nav_", "ent_", "script_", "logaddress_", "rr_", "cast_", "navspace_", "markup_", "spawn_", "vis_", "telemetry_", "test_", "soundscape_", "scene_", "particle_", "shatterglass_", "create_", "debugoverlay_", "prop_", "g_", "ff_", "cash_", "contributionscore_"]
+SHARED_PREFIXES = ["ai_", "weapon_", "ragdoll_", "ik_", "skeleton_"]
+
+def get_prefix(command_name: str):
+    """Extracts the prefix from a command name."""
+    if command_name.startswith('+'):
+        return '+'
+    parts = command_name.split('_')
+    if len(parts) > 1:
+        return f"{parts[0]}_"
+    return None
+
+def get_command_category(command: dict) -> str:
+    """
+    Determines the category of a command based on a set of rules.
+
+    Args:
+        command: A dictionary representing a command.
+
+    Returns:
+        A string indicating the category: "server", "player", "shared", or "uncategorized".
+    """
+    manual_category = command.get('uiData', {}).get('manual_category')
+    if manual_category:
+        category, _ = manual_category.split('/')
+        return category
+
+    flags = command.get('consoleData', {}).get('flags', [])
+    is_server = 'sv' in flags
+    is_client = 'cl' in flags
+    is_replicated = 'rep' in flags
+    is_archived = 'a' in flags
+    is_user = 'user' in flags
+    command_name = command['command']
+    prefix = get_prefix(command_name)
+
+    if is_replicated or (is_server and is_client):
+        return "shared"
+    elif is_server:
+        return "server"
+    elif is_client:
+        return "player"
+    elif prefix in PLAYER_PREFIXES:
+        return "player"
+    elif prefix in SERVER_PREFIXES:
+        return "server"
+    elif prefix in SHARED_PREFIXES:
+        return "shared"
+    elif is_archived or is_user:
+        return "player"
+    else:
+        return "uncategorized"


### PR DESCRIPTION
I have moved the logic for numeric detection and command splitting into their own dedicated rule files.

This change improves the modularity and maintainability of my internal code, following an existing pattern I've used for other classification tasks. I also fixed some related file path issues to ensure everything runs correctly.